### PR TITLE
42 docker image zrobic

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/angular-waytogo:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:latest
+
+
+ENV API_URL http://localhost:8090/api
+
+
+ADD dist/way-to-go-front-end /usr/share/nginx/html/
+
+ADD docker/etc/nginx/templates/ /etc/nginx/templates/
+
+EXPOSE 80

--- a/angular.json
+++ b/angular.json
@@ -45,15 +45,16 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "600kb",
+                  "maximumError": "700kb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "200kb",
+                  "maximumError": "250kb"
                 }
-              ],
+              ]
+            ,
               "outputHashing": "all"
             },
             "development": {
@@ -67,7 +68,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-
+            "proxyConfig": "src/proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/docker/etc/nginx/templates/default.conf.template
+++ b/docker/etc/nginx/templates/default.conf.template
@@ -1,0 +1,18 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location /api {
+        proxy_pass ${API_URL};  # Use service name from Docker Compose
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        root   /usr/share/nginx/html/browser;
+        index  index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/app/shared/http.config.ts
+++ b/src/app/shared/http.config.ts
@@ -1,3 +1,3 @@
 export const maxPageSize = 2147483647;
 export const defaultPageSize = 16;
-export const backendUrl = 'http://localhost:8090/api/v1'
+export const backendUrl = '/api/v1'

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8090",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
Co nowego:


* dodalem workflow - na kazdym pushu na main bedzie tworzony obraz dockerowy i wypychany na docker huba
* już nie ma url zhardcodowanego ''http://localhost:8090/api/v1", zamiast tego jest samo "/api/v1", a angular bedzie akzdy zapytanie na api przekierowywal jako proxy, w proxy.conf.json jest host, w docker compose bedzie mozna jedna linijka zmienic po prostu gdzie ma sie odwolywac
* Dockerfile co pakuje na nginx do obrazu